### PR TITLE
GitHub Actionの通知設定を変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v3.0.0
-        if: always()
+        if: failure()
         with:
           type: ${{ job.status }}
           job_name: '*${{ github.workflow }}*'


### PR DESCRIPTION
GitHub Actionの通知設定を変更．
失敗した時だけSlack通知を送る．