### PR TITLE
Renovateが動くNode.jsのバージョンが上がったため，テストに使うNode.jsのバージョンを変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Renovateが動くNode.jsのバージョンが上がったため，テストに使うNode.jsのバージョンを変更。

Node.js v12からv16に更新。