### PR TITLE
renovate-config-validatorのオプション変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
                         -not -name package-lock.json \
                         -exec basename {} \; | \
                     sort | \
-                    xargs npx renovate-config-validator
+                    xargs npx renovate-config-validator --strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,13 @@ jobs:
 
             -   name: Validate renovate config
                 run: |
-                    for file in `find . -maxdepth 1 -type f -name "*.json" -not -name package.json -not -name package-lock.json -exec basename {} \; | sort`; do
-                        echo "Validate ${file}"
-                        RENOVATE_CONFIG_FILE=${file} npx renovate-config-validator
-                    done
+                    find \
+                        . \
+                        -maxdepth 1 \
+                        -type f \
+                        -name "*.json" \
+                        -not -name package.json \
+                        -not -name package-lock.json \
+                        -exec basename {} \; | \
+                    sort | \
+                    xargs npx renovate-config-validator


### PR DESCRIPTION
## プルリクエストの説明

CIで実行しているrenovate-config-validatorのオプション変更
- いつの間にか引数でファイル名を指定できるようになっていたので，`RENOVATE_CONFIG_FILE`環境変数を使うのをやめて引数で指定するようにした
- Warningの時点でエラーにできる`--strict`オプションを有効化

## チェックリスト

- [ ] 設定ファイルを追加・更新・削除した場合，README.mdの説明を変更した?
