### PR TITLE
matchPackagePrefixesをやめてmatchPackageNamesに統合する

### DIFF
--- a/groupLinters.json
+++ b/groupLinters.json
@@ -9,10 +9,8 @@
             ],
             "matchPackageNames": [
                 "typescript-eslint",
-                "prettier"
-            ],
-            "matchPackagePrefixes": [
-                "prettier-plugin"
+                "prettier",
+                "prettier-plugin{/,}**"
             ]
         }
     ]

--- a/groupVeeValidate.json
+++ b/groupVeeValidate.json
@@ -4,8 +4,7 @@
     "packageRules": [
         {
             "groupName": "vee-validate",
-            "matchPackageNames": ["vee-validate"],
-            "matchPackagePrefixes": ["@vee-validate/"]
+            "matchPackageNames": ["vee-validate", "@vee-validate/{/,}**"]
         }
     ]
 }


### PR DESCRIPTION
## プルリクエストの説明

<!-- ここに説明を書く -->

matchPackagePrefixesをやめてmatchPackageNamesに統合する
v39対応

## チェックリスト

- [ ] 設定ファイルを追加・更新・削除した場合，README.mdの説明を変更した?
